### PR TITLE
Ensure the metrics path can be customized.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,15 @@ impl HttpMetricsLayer {
             .with_state(self.state.clone())
     }
 
+    /// Create a Router that has a customized listen metrics path
+    /// instead of `/metrics`.  You can merge this router into
+    /// your application's router to serve metrics.
+    pub fn path_route<S>(&self, path: String) -> Router<S> {
+        Router::new()
+            .route(path.as_str(), get(Self::exporter_handler))
+            .with_state(self.state.clone())
+    }
+
     // TODO use a static global exporter like autometrics-rs?
     // https://github.com/autometrics-dev/autometrics-rs/blob/d3e7bffeede43f6c77b6a992b0443c0fca34003f/autometrics/src/prometheus_exporter.rs#L10
     pub async fn exporter_handler(state: State<MetricState>) -> impl IntoResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,10 @@ impl Default for HttpMetricsLayerBuilder {
 
 impl HttpMetricsLayerBuilder {
     pub fn new() -> Self {
-        let mut v = Self::default();
-        v.path = "/metrics".to_string();
-        v
+        HttpMetricsLayerBuilder {
+            path: "/metrics".to_string(),
+            ..Default::default()
+        }
     }
 
     pub fn with_service_name(mut self, service_name: String) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,16 +206,21 @@ pub struct HttpMetricsLayerBuilder {
 
 impl Default for HttpMetricsLayerBuilder {
     fn default() -> Self {
-        HttpMetricsLayerBuilder::new()
+        Self {
+            service_name: None,
+            service_version: None,
+            prefix: None,
+            path: "/metrics".to_string(),
+            labels: None,
+            skipper: PathSkipper::default(),
+            is_tls: false,
+        }
     }
 }
 
 impl HttpMetricsLayerBuilder {
     pub fn new() -> Self {
-        HttpMetricsLayerBuilder {
-            path: "/metrics".to_string(),
-            ..Default::default()
-        }
+        HttpMetricsLayerBuilder::default()
     }
 
     pub fn with_service_name(mut self, service_name: String) -> Self {


### PR DESCRIPTION
With this, users gain the ability to customize the URL path at which metrics are served.